### PR TITLE
fix(args): handle quotes in passed args

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ./
         with:
           config: fixtures/cliff.toml
-          args: --verbose --strip footer
+          args: --verbose --strip 'footer'
         env:
           OUTPUT: fixtures/CHANGELOG.md
       - name: Print the changelog

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ./
         with:
           config: fixtures/cliff.toml
-          args: --verbose --strip 'footer'
+          args: --verbose --strip 'footer' --exclude-path '.github/**'
         env:
           OUTPUT: fixtures/CHANGELOG.md
       - name: Print the changelog

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,16 @@
 #!/bin/bash -l
 set -uxo pipefail
 
+# Avoid file expansion when passing parameters like with '*'
+set -o noglob
+
 OUTPUT=${OUTPUT:="git-cliff/CHANGELOG.md"}
 
 # Create the output directory
 mkdir -p "$(dirname $OUTPUT)"
 
 # Separate arguments before passing them to git-cliff command
-args=$(echo $@ | xargs)
+args=$(echo "$@" | xargs)
 
 # Execute git-cliff
 GIT_CLIFF_OUTPUT="$OUTPUT" git-cliff $args

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,11 @@ OUTPUT=${OUTPUT:="git-cliff/CHANGELOG.md"}
 # Create the output directory
 mkdir -p "$(dirname $OUTPUT)"
 
+# Separate arguments before passing them to git-cliff command
+args=$(echo $@ | xargs)
+
 # Execute git-cliff
-GIT_CLIFF_OUTPUT="$OUTPUT" git-cliff $@
+GIT_CLIFF_OUTPUT="$OUTPUT" git-cliff $args
 exit_code=$?
 
 # Output to console


### PR DESCRIPTION
I added a test, which you can see failing [here](https://github.com/chamini2/git-cliff-action/actions/runs/3381265201/jobs/5614986222#step:3:76)
And then passing [here](https://github.com/chamini2/git-cliff-action/actions/runs/3381544568/jobs/5615563988#step:3:79)

This is important for us for a bunch of include-paths we are passing https://github.com/fal-ai/fal/actions/runs/3380681878/workflow#L92-L100