### PR TITLE
feat(action): add an output for the changelog content

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This action generates a changelog based on your Git history using [git-cliff](ht
 ### Output variables
 
 - `changelog`: Output file that contains the generated changelog.
+- `content`: Content of the changelog.
 
 ### Environment variables
 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
 outputs:
   changelog:
     description: "output file"
+  content:
+    description: "content of the changelog"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,15 +23,15 @@ exit_code=$?
 
 # Output to console
 cat "$OUTPUT"
-OUTPUT="$WORKDIR/$OUTPUT"
-
-# Set output file
-echo "changelog=$OUTPUT" >> $GITHUB_OUTPUT
 
 # Set the changelog content
 echo "content<<EOF" >> $GITHUB_OUTPUT
 cat "$OUTPUT" >> $GITHUB_OUTPUT
-echo "EOF"
+echo "EOF" >> $GITHUB_OUTPUT
+
+# Set output file
+OUTPUT="$WORKDIR/$OUTPUT"
+echo "changelog=$OUTPUT" >> $GITHUB_OUTPUT
 
 # Pass exit code to the next step
 echo "exit_code=$exit_code" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,12 @@ exit_code=$?
 cat "$OUTPUT"
 
 # Set output file
-echo "::set-output name=changelog::$OUTPUT"
+echo "changelog=$OUTPUT" >> $GITHUB_OUTPUT
+
+# Set the changelog content
+echo "content<<EOF" >> $GITHUB_OUTPUT
+cat "$OUTPUT" >> $GITHUB_OUTPUT
+echo "EOF"
 
 # Pass exit code to the next step
-echo "::set-output name=exit_code::$exit_code"
+echo "exit_code=$exit_code" >> $GITHUB_OUTPUT


### PR DESCRIPTION
`::set-output` is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in favor of [environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files). This has better multiline support, so add the contents of the changelog as an output for cases where you are creating a GitHub release.

BREAKING CHANGE: self-hosted runners will need to be at 2.297.0 or greater