### PR TITLE
feat(action): add output for the latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,10 @@ jobs:
         uses: ./
         with:
           config: fixtures/cliff.toml
-          args: --verbose --strip 'footer' --exclude-path '.github/**'
+          args: --verbose --strip 'footer' --exclude-path '.github/**' --tag 0.0.0
         env:
           OUTPUT: fixtures/CHANGELOG.md
       - name: Print the changelog
         run: cat "${{ steps.git-cliff.outputs.changelog }}"
+      - name: Print the version
+        run: echo "${{ steps.git-cliff.outputs.version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ COPY README.md /
 COPY LICENSE /
 COPY entrypoint.sh /entrypoint.sh
 
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This action generates a changelog based on your Git history using [git-cliff](ht
 
 - `changelog`: Output file that contains the generated changelog.
 - `content`: Content of the changelog.
+- `version`: Version of the latest release.
 
 ### Environment variables
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,8 @@ outputs:
     description: "output file"
   content:
     description: "content of the changelog"
+  version:
+    description: "version of the latest release"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,10 @@ args=$(echo "$@" | xargs)
 GIT_CLIFF_OUTPUT="$OUTPUT" git-cliff $args
 exit_code=$?
 
+# Retrieve context
+CONTEXT="$(mktemp)"
+GIT_CLIFF_OUTPUT="$CONTEXT" git-cliff $args --context
+
 # Output to console
 cat "$OUTPUT"
 
@@ -32,6 +36,9 @@ echo "EOF" >>$GITHUB_OUTPUT
 
 # Set output file
 echo "changelog=$OUTPUT" >>$GITHUB_OUTPUT
+
+# Set the version output to the version of the latest release
+echo "version=$(jq -r '.[0].version' $CONTEXT)" >>$GITHUB_OUTPUT
 
 # Pass exit code to the next step
 echo "exit_code=$exit_code" >>$GITHUB_OUTPUT


### PR DESCRIPTION
This PR introduces a `version` output that holds the version of the latest release.

This output allows subsequent steps to retrieve and use the version string for further processing, such as updating a `package.json` file.

---

Related discussion: https://github.com/orhun/git-cliff-action/discussions/11