### PR TITLE
docs(readme): add GITHUB_REPO env in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ jobs:
           args: -vv --latest --strip header
         env:
           OUTPUT: CHANGES.md
+          GITHUB_REPO: ${{ github.repository }}
 
       # use release body in the same job
       - name: Upload the binary releases
@@ -123,6 +124,7 @@ jobs:
           args: --verbose
         env:
           OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
 
       - name: Commit
         run: |


### PR DESCRIPTION
needed in order to generate detailed Github release notes, including e.g. new contributors, etc.

ref:
https://github.com/orhun/git-cliff/blob/main/examples/github.toml
https://git-cliff.org/docs/integration/github#setting-up-the-remote