### PR TITLE
fix(install): fix running on windows host

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,12 @@ set -uxo pipefail
 # Avoid file expansion when passing parameters like with '*'
 set -o noglob
 
+GIT_CLIFF_BIN='git-cliff'
+
+if [[ "${RUNNER_OS}" == 'Windows' ]]; then
+    GIT_CLIFF_BIN="${GIT_CLIFF_BIN}.exe"
+fi
+
 # Set up working directory
 owner=$(stat -c "%u:%g" .)
 chown -R "$(id -u)" .
@@ -17,12 +23,12 @@ mkdir -p "$(dirname $OUTPUT)"
 args=$(echo "$@" | xargs)
 
 # Execute git-cliff
-GIT_CLIFF_OUTPUT="$OUTPUT" ./bin/git-cliff $args
+GIT_CLIFF_OUTPUT="$OUTPUT" ./bin/${GIT_CLIFF_BIN} $args
 exit_code=$?
 
 # Retrieve context
 CONTEXT="$(mktemp)"
-GIT_CLIFF_OUTPUT="$CONTEXT" ./bin/git-cliff $args --context
+GIT_CLIFF_OUTPUT="$CONTEXT" ./bin/${GIT_CLIFF_BIN} $args --context
 
 # Revert permissions
 chown -R "$owner" .
@@ -31,10 +37,10 @@ chown -R "$owner" .
 FILESIZE=$(stat -c%s "$OUTPUT")
 MAXSIZE=$((40 * 1024 * 1024))
 if [ "$FILESIZE" -le "$MAXSIZE" ]; then
-  echo "content<<EOF" >>$GITHUB_OUTPUT
-  cat "$OUTPUT" >>$GITHUB_OUTPUT
-  echo "EOF" >>$GITHUB_OUTPUT
-  cat "$OUTPUT"
+    echo "content<<EOF" >>$GITHUB_OUTPUT
+    cat "$OUTPUT" >>$GITHUB_OUTPUT
+    echo "EOF" >>$GITHUB_OUTPUT
+    cat "$OUTPUT"
 fi
 
 # Set output file


### PR DESCRIPTION
# What's changed.

`.exe` extension for Windows host has been added for binary files.

## install.sh

```sh
set -euo pipefail
```


Added `-e` flag to exit the script if return code of one of the commands is different from `0`.
For example if `curl` command with `--fail` option will fail, script will continue to execute without this flag.

A choice of extension and unpacker (`.zip` and `7z` for Windows) was added to the host system detection part.

## run.sh

Fixed stylistic errors, `install.sh` used 4 tabs for indentation, while `run.sh` used only 2.

## Note

Please merge the last two commits because they fix the same problem.