### PR TITLE
Install & run sh files Shellcheck warnings fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,7 @@ if [[ ! -e "$TARGET" ]]; then
     curl --silent --show-error --fail --location --output "$TARGET" "$LOCATION"
     echo "Unpacking ${TARGET}..."
     ${ARCHIVE_CMD} "$TARGET"
-    mv git-cliff-${TAG_NAME:1}/${GIT_CLIFF_BIN} "./bin/$GIT_CLIFF_BIN"
+    mv git-cliff-"${TAG_NAME:1}"/${GIT_CLIFF_BIN} "./bin/${GIT_CLIFF_BIN}"
 else
     echo "Using cached git-cliff binary."
 fi


### PR DESCRIPTION
Greetings @orhun,

I follow you for your projects and works. Good work!

I want to make a small contribution to this project. I provided a short review for warning messages using Shellcheck. However, I am not familiar with the project and spent a short time. I could definitely be wrong. I am creating a PR for testing. I will look at the content that does not progress properly in actions. Also, if you can guide me with explanations, I would like to help more.

Good day, greetings from the broadcast!

Additional Note: If you deem it appropriate, you can automatically check the contents of the bash scripts with shellcheck during PR checks, this can be useful when there are syntax-based errors or warnings.