### PR TITLE
fix: --context flag must come before args

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,7 +28,7 @@ exit_code=$?
 
 # Retrieve context
 CONTEXT="$(mktemp)"
-GIT_CLIFF_OUTPUT="$CONTEXT" ./bin/${GIT_CLIFF_BIN} $args --context
+GIT_CLIFF_OUTPUT="$CONTEXT" ./bin/${GIT_CLIFF_BIN} --context $args
 
 # Revert permissions
 chown -R "$owner" .


### PR DESCRIPTION
Using this action, I have the following error:

```
+ ./bin/git-cliff --config=cliff.toml -- 1.0.0..1.10.0 --context
error: unexpected argument '--context' found

Usage: git-cliff [FLAGS] [OPTIONS] [--] [RANGE]
```

I'm providing `args: -- prev_tag..current_tag`.

This PR should fix the error.

Thanks