### PR TITLE
fix(install): install in temp path instead of user working dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,8 @@ fi
 set -euo pipefail
 
 ARCHIVE_EXT='tar.gz'
-ARCHVIE_CMD='tar -xf'
+ARCHIVE_CMD='tar -xf'
 GIT_CLIFF_BIN='git-cliff'
-
-GIT_CLIFF_DIR="$GITHUB_ACTION_PATH/bin"
 
 case "${RUNNER_OS}" in
     macOS)   
@@ -19,7 +17,7 @@ case "${RUNNER_OS}" in
     Windows) 
         OS=pc-windows-msvc
         ARCHIVE_EXT='zip'
-        ARCHVIE_CMD='7z x -aoa'
+        ARCHIVE_CMD='7z x -aoa'
         GIT_CLIFF_BIN="${GIT_CLIFF_BIN}.exe"
         ;;
     *)
@@ -32,6 +30,10 @@ case "${RUNNER_ARCH}" in
     X86)   ARCH=i686 ;;
     *)     ARCH=x86_64 ;;
 esac
+
+INSTALL_DIR="$RUNNER_TEMP/git-cliff"
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
 
 echo "git-cliff-${ARCH}-${OS}.${ARCHIVE_EXT}"
 
@@ -71,7 +73,7 @@ if [[ ! -e "$TARGET" ]]; then
     echo "Downloading ${TARGET}..."
     curl --silent --show-error --fail --location --output "$TARGET" "$LOCATION"
     echo "Unpacking ${TARGET}..."
-    ${ARCHVIE_CMD} "$TARGET"
+    ${ARCHIVE_CMD} "$TARGET"
     mv git-cliff-${TAG_NAME:1}/${GIT_CLIFF_BIN} "$GIT_CLIFF_DIR/$GIT_CLIFF_BIN"
 else
     echo "Using cached git-cliff binary."

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,8 @@ ARCHIVE_EXT='tar.gz'
 ARCHVIE_CMD='tar -xf'
 GIT_CLIFF_BIN='git-cliff'
 
+GIT_CLIFF_DIR="$GITHUB_ACTION_PATH/bin"
+
 case "${RUNNER_OS}" in
     macOS)   
         OS=apple-darwin
@@ -62,7 +64,7 @@ LOCATION="$(echo "${RELEASE_INFO}" |
 echo "Found release: ${LOCATION}"
 
 # Create bin directory
-mkdir -p ./bin
+mkdir -p "$GIT_CLIFF_DIR"
 
 # Skip downloading release if downloaded already, e.g. when the action is used multiple times.
 if [[ ! -e "$TARGET" ]]; then
@@ -70,7 +72,7 @@ if [[ ! -e "$TARGET" ]]; then
     curl --silent --show-error --fail --location --output "$TARGET" "$LOCATION"
     echo "Unpacking ${TARGET}..."
     ${ARCHVIE_CMD} "$TARGET"
-    mv git-cliff-${TAG_NAME:1}/${GIT_CLIFF_BIN} ./bin/${GIT_CLIFF_BIN}
+    mv git-cliff-${TAG_NAME:1}/${GIT_CLIFF_BIN} "$GIT_CLIFF_DIR/$GIT_CLIFF_BIN"
 else
     echo "Using cached git-cliff binary."
 fi

--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ LOCATION="$(echo "${RELEASE_INFO}" |
 echo "Found release: ${LOCATION}"
 
 # Create bin directory
-mkdir -p "$GIT_CLIFF_DIR"
+mkdir -p ./bin
 
 # Skip downloading release if downloaded already, e.g. when the action is used multiple times.
 if [[ ! -e "$TARGET" ]]; then
@@ -74,7 +74,7 @@ if [[ ! -e "$TARGET" ]]; then
     curl --silent --show-error --fail --location --output "$TARGET" "$LOCATION"
     echo "Unpacking ${TARGET}..."
     ${ARCHIVE_CMD} "$TARGET"
-    mv git-cliff-${TAG_NAME:1}/${GIT_CLIFF_BIN} "$GIT_CLIFF_DIR/$GIT_CLIFF_BIN"
+    mv git-cliff-${TAG_NAME:1}/${GIT_CLIFF_BIN} "./bin/$GIT_CLIFF_BIN"
 else
     echo "Using cached git-cliff binary."
 fi

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,8 @@ if [[ "${RUNNER_OS}" == 'Windows' ]]; then
     GIT_CLIFF_BIN="${GIT_CLIFF_BIN}.exe"
 fi
 
+GIT_CLIFF_PATH="$GITHUB_ACTION_PATH/bin/$GIT_CLIFF_BIN"
+
 # Set up working directory
 owner=$(stat -c "%u:%g" .)
 chown -R "$(id -u)" .
@@ -23,12 +25,12 @@ mkdir -p "$(dirname $OUTPUT)"
 args=$(echo "$@" | xargs)
 
 # Execute git-cliff
-GIT_CLIFF_OUTPUT="$OUTPUT" ./bin/${GIT_CLIFF_BIN} $args
+GIT_CLIFF_OUTPUT="$OUTPUT" "$GIT_CLIFF_PATH" $args
 exit_code=$?
 
 # Retrieve context
 CONTEXT="$(mktemp)"
-GIT_CLIFF_OUTPUT="$CONTEXT" ./bin/${GIT_CLIFF_BIN} --context $args
+GIT_CLIFF_OUTPUT="$CONTEXT" "$GIT_CLIFF_PATH" --context $args
 
 # Revert permissions
 chown -R "$owner" .

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,8 @@ if [[ "${RUNNER_OS}" == 'Windows' ]]; then
     GIT_CLIFF_BIN="${GIT_CLIFF_BIN}.exe"
 fi
 
-GIT_CLIFF_PATH="$GITHUB_ACTION_PATH/bin/$GIT_CLIFF_BIN"
+INSTALL_DIR="$RUNNER_TEMP/git-cliff"
+GIT_CLIFF_PATH="$INSTALL_DIR/bin/$GIT_CLIFF_BIN"
 
 # Set up working directory
 owner=$(stat -c "%u:%g" .)

--- a/run.sh
+++ b/run.sh
@@ -11,8 +11,7 @@ if [[ "${RUNNER_OS}" == 'Windows' ]]; then
     GIT_CLIFF_BIN="${GIT_CLIFF_BIN}.exe"
 fi
 
-INSTALL_DIR="$RUNNER_TEMP/git-cliff"
-GIT_CLIFF_PATH="$INSTALL_DIR/bin/$GIT_CLIFF_BIN"
+GIT_CLIFF_PATH="$RUNNER_TEMP/git-cliff/bin/$GIT_CLIFF_BIN"
 
 # Set up working directory
 owner=$(stat -c "%u:%g" .)


### PR DESCRIPTION
The action is currently installing the artifacts into the user's working dir. This conflicts with further steps, like git commit, that the user might want to do. See the picture below.

![image](https://github.com/user-attachments/assets/f917abfc-fdae-4562-b359-1d099f9968b8)

The proposed change is to install the artifacts in a temporary directory to solve this. On the other hand, fixed a typo in `ARCHIVE_CMD`.

