### PR TITLE
fix(run): exit with correct exit code

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -71,3 +71,6 @@ echo "version=$(jq -r '.[0].version' $CONTEXT)" >>$GITHUB_OUTPUT
 
 # Pass exit code to the next step
 echo "exit_code=$exit_code" >>$GITHUB_OUTPUT
+
+# Exit with git-cliff exit_code
+exit $exit_code


### PR DESCRIPTION
Set the exit status of the action to the exit status of git-cliff run