### PR TITLE
fix: stop `env.GITHUB_TOKEN` from overriding `github_token` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action generates a changelog based on your Git history using [git-cliff](ht
 - `version`: `git-cliff` version to use. (e.g. `"latest"`, `"v2.12.0"`)
 - `config`: Path of the configuration file. (Default: `"cliff.toml"`)
 - `args`: [Arguments](https://github.com/orhun/git-cliff#usage) to pass to git-cliff. (Default: `"-v"`)
-- `github_token`: The GitHub API token used to get `git-cliff` release information via the GitHub API to avoid rate limits. (Default: `${{ github.token }}`)
+- `github_token`: The GitHub API token used to download `git-cliff` (to avoid rate limits) and to authenticate git-cliff's [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links). Requires a classic or fine-grained token without permissions. (Default: `${{ github.token }}`)
 
 ### Output variables
 

--- a/action.yml
+++ b/action.yml
@@ -37,14 +37,14 @@ runs:
         RUNNER_OS: ${{ runner.os }}
         RUNNER_ARCH: ${{ runner.arch }}
         VERSION: ${{ inputs.version }}
-        GITHUB_API_TOKEN: ${{ env.GITHUB_TOKEN || inputs.github_token }}
+        GITHUB_API_TOKEN: ${{ inputs.github_token }}
 
     - name: Run git-cliff
       id: run-git-cliff
       shell: bash
       run: ${GITHUB_ACTION_PATH}/run.sh --config=${{ inputs.config }} ${{ inputs.args }}
       env:
-        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN || inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
 branding:
   icon: "triangle"


### PR DESCRIPTION
closes: #72 

Previously, `GITHUB_API_TOKEN` and `GITHUB_TOKEN` were resolved as `env.GITHUB_TOKEN || inputs.github_token`, meaning the environment variable took priority over the action input. On Forgejo/Gitea runners, `GITHUB_TOKEN` is automatically set to a non-GitHub token, which silently overrode any user-provided github_token input and caused GitHub API calls to fail.

Simple tests from me:
- https://codeberg.org/Maks1mS/test-git-cliff-action/actions/runs/2/jobs/1/attempt/1
- https://github.com/Maks1mS/test-git-cliff-action/actions/runs/22303424296/job/64516596567