### PR TITLE
ci(workflows): add automated git-cliff version sync

### DIFF
--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -1,0 +1,65 @@
+name: Sync git-cliff version
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Get latest git-cliff release
+        id: latest
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/orhun/git-cliff/releases/latest | jq -r .tag_name)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Read current default version
+        id: current
+        run: |
+          VERSION=$(yq '.inputs.version.default' action.yml)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Bump version
+        if: steps.latest.outputs.version != steps.current.outputs.version
+        run: |
+          yq -i ".inputs.version.default = \"${{ steps.latest.outputs.version }}\"" action.yml
+      - name: Create PR
+        if: steps.latest.outputs.version != steps.current.outputs.current
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: bump git-cliff to ${{ steps.latest.outputs.version }}"
+          branch: bump-git-cliff-${{ steps.latest.outputs.version }}
+          title: "chore: bump git-cliff to ${{ steps.latest.outputs.version }}"
+      - name: Create PR
+        if: steps.latest.outputs.version != steps.current.outputs.version
+        env:
+          VERSION: ${{ steps.latest.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="bump-git-cliff-${VERSION}"
+          MESSAGE="chore: bump git-cliff to ${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$BRANCH"
+          git add action.yml
+          git commit -m "$MESSAGE" || echo "Nothing to commit"
+          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git "$BRANCH" --force
+
+          echo "${GITHUB_TOKEN}" | gh auth login --with-token
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "$MESSAGE" \
+            --body "$MESSAGE" \
+            || echo "PR already exists"

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -2,7 +2,7 @@ name: Sync git-cliff version
 
 on:
   schedule:
-    - cron: '0 3 * * 1'
+    - cron: '0 3 * * 1' # every Monday at 03:00 UTC
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -31,13 +31,6 @@ jobs:
         run: |
           yq -i ".inputs.version.default = \"${{ steps.latest.outputs.version }}\"" action.yml
       - name: Create PR
-        if: steps.latest.outputs.version != steps.current.outputs.current
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "chore: bump git-cliff to ${{ steps.latest.outputs.version }}"
-          branch: bump-git-cliff-${{ steps.latest.outputs.version }}
-          title: "chore: bump git-cliff to ${{ steps.latest.outputs.version }}"
-      - name: Create PR
         if: steps.latest.outputs.version != steps.current.outputs.version
         env:
           VERSION: ${{ steps.latest.outputs.version }}

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -28,24 +28,29 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Bump version
         if: steps.latest.outputs.version != steps.current.outputs.version
+        env:
+          CURRENT: ${{ steps.current.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
         run: |
-          yq -i ".inputs.version.default = \"${{ steps.latest.outputs.version }}\"" action.yml
+          yq -i ".inputs.version.default = \"${LATEST}\"" action.yml
+          sed -i "s|${CURRENT}|${LATEST}|g" README.md
       - name: Create PR
         if: steps.latest.outputs.version != steps.current.outputs.version
         env:
-          VERSION: ${{ steps.latest.outputs.version }}
+          LATEST: ${{ steps.latest.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
-          BRANCH="chore/git-cliff-${VERSION}"
-          MESSAGE="chore: bump git-cliff to ${VERSION}"
+          BRANCH="chore/git-cliff-${LATEST}"
+          MESSAGE="chore: bump git-cliff to ${LATEST}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git checkout -B "$BRANCH"
           git add action.yml
+          git add README.md
           git commit -m "$MESSAGE" || echo "Nothing to commit"
           git push origin "$BRANCH" --force
 

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -19,11 +19,13 @@ jobs:
       - name: Get latest git-cliff release
         id: latest
         run: |
+          set -euo pipefail
           VERSION=$(curl -s https://api.github.com/repos/orhun/git-cliff/releases/latest | jq -r .tag_name)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Read current default version
         id: current
         run: |
+          set -euo pipefail
           VERSION=$(yq '.inputs.version.default' action.yml)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Bump version
@@ -32,6 +34,7 @@ jobs:
           CURRENT: ${{ steps.current.outputs.version }}
           LATEST: ${{ steps.latest.outputs.version }}
         run: |
+          set -euo pipefail
           yq -i ".inputs.version.default = \"${LATEST}\"" action.yml
           sed -i "s|${CURRENT}|${LATEST}|g" README.md
       - name: Create PR

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -46,7 +46,10 @@ jobs:
           set -euo pipefail
 
           BRANCH="chore/git-cliff-${LATEST}"
-          MESSAGE="chore: bump git-cliff to ${LATEST}"
+          TITLE="chore: bump git-cliff to ${LATEST}"
+          BODY="This PR bumps git-cliff to ${LATEST}.
+
+          🔗 https://github.com/orhun/git-cliff/releases/tag/${LATEST}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -54,13 +57,13 @@ jobs:
           git checkout -B "$BRANCH"
           git add action.yml
           git add README.md
-          git commit -m "$MESSAGE" || echo "Nothing to commit"
+          git commit -m "$TITLE" || echo "Nothing to commit"
           git push origin "$BRANCH" --force
 
           echo "${GITHUB_TOKEN}" | gh auth login --with-token
           gh pr create \
             --base main \
             --head "$BRANCH" \
-            --title "$MESSAGE" \
-            --body "$MESSAGE" \
+            --title "$TITLE" \
+            --body "$BODY" \
             || echo "PR already exists"

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -21,13 +21,13 @@ jobs:
         run: |
           set -euo pipefail
           VERSION=$(curl -s https://api.github.com/repos/orhun/git-cliff/releases/latest | jq -r .tag_name)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> ${GITHUB_OUTPUT}
       - name: Read current default version
         id: current
         run: |
           set -euo pipefail
           VERSION=$(yq '.inputs.version.default' action.yml)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> ${GITHUB_OUTPUT}
       - name: Bump version
         if: steps.latest.outputs.version != steps.current.outputs.version
         env:
@@ -54,16 +54,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git checkout -B "$BRANCH"
+          git checkout -B "${BRANCH}"
           git add action.yml
           git add README.md
-          git commit -m "$TITLE" || echo "Nothing to commit"
-          git push origin "$BRANCH" --force
+          git commit -m "${TITLE}" || echo "Nothing to commit"
+          git push origin "${BRANCH}" --force
 
           echo "${GITHUB_TOKEN}" | gh auth login --with-token
           gh pr create \
             --base main \
-            --head "$BRANCH" \
-            --title "$TITLE" \
-            --body "$BODY" \
+            --head "${BRANCH}" \
+            --title "${TITLE}" \
+            --body "${BODY}" \
             || echo "PR already exists"

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          BRANCH="bump-git-cliff-${VERSION}"
+          BRANCH="chore/git-cliff-${VERSION}"
           MESSAGE="chore: bump git-cliff to ${VERSION}"
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -2,7 +2,7 @@ name: Sync git-cliff version
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -35,7 +35,7 @@ jobs:
           LATEST: ${{ steps.latest.outputs.version }}
         run: |
           set -euo pipefail
-          yq -i ".inputs.version.default = \"${LATEST}\"" action.yml
+          sed -i "s|${CURRENT}|${LATEST}|g" action.yml
           sed -i "s|${CURRENT}|${LATEST}|g" README.md
       - name: Create PR
         if: steps.latest.outputs.version != steps.current.outputs.version

--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -47,7 +47,7 @@ jobs:
           git checkout -B "$BRANCH"
           git add action.yml
           git commit -m "$MESSAGE" || echo "Nothing to commit"
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git "$BRANCH" --force
+          git push origin "$BRANCH" --force
 
           echo "${GITHUB_TOKEN}" | gh auth login --with-token
           gh pr create \

--- a/action.yml
+++ b/action.yml
@@ -38,12 +38,14 @@ runs:
         RUNNER_ARCH: ${{ runner.arch }}
         VERSION: ${{ inputs.version }}
         GITHUB_API_TOKEN: ${{ env.GITHUB_TOKEN || inputs.github_token }}
+
     - name: Run git-cliff
       id: run-git-cliff
       shell: bash
       run: ${GITHUB_ACTION_PATH}/run.sh --config=${{ inputs.config }} ${{ inputs.args }}
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN || inputs.github_token }}
+
 branding:
   icon: "triangle"
   color: "green"

--- a/action.yml
+++ b/action.yml
@@ -38,14 +38,12 @@ runs:
         RUNNER_ARCH: ${{ runner.arch }}
         VERSION: ${{ inputs.version }}
         GITHUB_API_TOKEN: ${{ env.GITHUB_TOKEN || inputs.github_token }}
-
     - name: Run git-cliff
       id: run-git-cliff
       shell: bash
       run: ${GITHUB_ACTION_PATH}/run.sh --config=${{ inputs.config }} ${{ inputs.args }}
       env:
         GITHUB_TOKEN: ${{ env.GITHUB_TOKEN || inputs.github_token }}
-
 branding:
   icon: "triangle"
   color: "green"


### PR DESCRIPTION
## Summary

This PR adds a workflow to automatically sync the `git-cliff` version used in this action with the latest upstream release.

Closes #73 

cc: @orhun @jaiakash 

## What it does

- Fetches the latest `git-cliff` release version from GitHub
- Compares it with the current default version in `action.yml`
- Creates a pull request if a new version is available
- Runs on a weekly schedule and via manual dispatch

## Motivation

This helps keep the action up-to-date without requiring manual version bumps, reducing maintenance overhead and the risk of falling behind upstream releases.

## Local testing

The following commands were tested locally to verify the behavior:

```bash
LATEST=$(curl -s https://api.github.com/repos/orhun/git-cliff/releases/latest | jq -r .tag_name) && echo $LATEST
CURRENT=$(yq '.inputs.version.default' action.yml) && echo $CURRENT
yq -i ".inputs.version.default = \"${LATEST}\"" action.yml
sed -i "s|${CURRENT}|${LATEST}|g" README.md
```
