### PR TITLE
Improve GitHub Token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action generates a changelog based on your Git history using [git-cliff](ht
 - `version`: `git-cliff` version to use. (e.g. `"latest"`, `"v2.12.0"`)
 - `config`: Path of the configuration file. (Default: `"cliff.toml"`)
 - `args`: [Arguments](https://github.com/orhun/git-cliff#usage) to pass to git-cliff. (Default: `"-v"`)
-- `github_token`: The GitHub API token used to get `git-cliff` release information via the GitHub API to avoid rate limits. (Default: `${{ github.token }}`)
+- `github_token`: The GitHub API token used to download `git-cliff` (to avoid rate limits) and to authenticate git-cliff's [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links). Requires a classic or fine-grained token without permissions. (Default: `${{ github.token }}`)
 
 ### Output variables
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ This action generates a changelog based on your Git history using [git-cliff](ht
 - `version`: `git-cliff` version to use. (e.g. `"latest"`, `"v2.12.0"`)
 - `config`: Path of the configuration file. (Default: `"cliff.toml"`)
 - `args`: [Arguments](https://github.com/orhun/git-cliff#usage) to pass to git-cliff. (Default: `"-v"`)
-- `github_token`: The GitHub API token used to download `git-cliff` and to authenticate git-cliff's [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links) to avoid rate limits. Requires a classic or fine-grained token without permissions. (Default: `${{ github.token }}`)
+- `github_token`: The GitHub API token used to download `git-cliff` and to authenticate git-cliff's [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links) to avoid rate limits. Requires a classic or fine-grained token without permissions.
+> [!NOTE]
+> GitHub API token order of precedence.
+> 1. Input variable `github_token`
+> 2. Environment variable `GITHUB_TOKEN`
+> 3. Github Context (default): `${{ github.token }}`
 
 ### Output variables
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ This action generates a changelog based on your Git history using [git-cliff](ht
 - `config`: Path of the configuration file. (Default: `"cliff.toml"`)
 - `args`: [Arguments](https://github.com/orhun/git-cliff#usage) to pass to git-cliff. (Default: `"-v"`)
 - `github_token`: The GitHub API token used to download `git-cliff` and to authenticate git-cliff's [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links) to avoid rate limits. Requires a classic or fine-grained token without permissions.
+
 > [!NOTE]
-> GitHub API token order of precedence.
-> 1. Input variable `github_token`
-> 2. Environment variable `GITHUB_TOKEN`
-> 3. Github Context (default): `${{ github.token }}`
+> GitHub API token order of precedence is as follows:
+>
+> 1. Input variable (`github_token`)
+> 2. Environment variable (`GITHUB_TOKEN`)
+> 3. GitHub context (default) (`${{ github.token }}`)
 
 ### Output variables
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action generates a changelog based on your Git history using [git-cliff](ht
 - `version`: `git-cliff` version to use. (e.g. `"latest"`, `"v2.12.0"`)
 - `config`: Path of the configuration file. (Default: `"cliff.toml"`)
 - `args`: [Arguments](https://github.com/orhun/git-cliff#usage) to pass to git-cliff. (Default: `"-v"`)
-- `github_token`: The GitHub API token used to download `git-cliff` (to avoid rate limits) and to authenticate git-cliff's [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links). Requires a classic or fine-grained token without permissions. (Default: `${{ github.token }}`)
+- `github_token`: The GitHub API token used to download `git-cliff` and to authenticate git-cliff's to the GitHub API [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links) to avoid rate limits. Requires a classic or fine-grained token without permissions. (Default: `${{ github.token }}`)
 
 ### Output variables
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action generates a changelog based on your Git history using [git-cliff](ht
 - `version`: `git-cliff` version to use. (e.g. `"latest"`, `"v2.12.0"`)
 - `config`: Path of the configuration file. (Default: `"cliff.toml"`)
 - `args`: [Arguments](https://github.com/orhun/git-cliff#usage) to pass to git-cliff. (Default: `"-v"`)
-- `github_token`: The GitHub API token used to download `git-cliff` and to authenticate git-cliff's to the GitHub API [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links) to avoid rate limits. Requires a classic or fine-grained token without permissions. (Default: `${{ github.token }}`)
+- `github_token`: The GitHub API token used to download `git-cliff` and to authenticate git-cliff's [GitHub integration](https://git-cliff.org/docs/integration/github) (e.g. extracting usernames, contributors, PR links) to avoid rate limits. Requires a classic or fine-grained token without permissions. (Default: `${{ github.token }}`)
 
 ### Output variables
 

--- a/action.yml
+++ b/action.yml
@@ -37,14 +37,14 @@ runs:
         RUNNER_OS: ${{ runner.os }}
         RUNNER_ARCH: ${{ runner.arch }}
         VERSION: ${{ inputs.version }}
-        GITHUB_API_TOKEN: ${{ env.GITHUB_TOKEN || inputs.github_token }}
+        GITHUB_API_TOKEN: ${{ inputs.github_token }}
 
     - name: Run git-cliff
       id: run-git-cliff
       shell: bash
       run: ${GITHUB_ACTION_PATH}/run.sh --config=${{ inputs.config }} ${{ inputs.args }}
       env:
-        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN || inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
 branding:
   icon: "triangle"

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ inputs:
   github_token:
     description: "GitHub API token"
     required: false
-    default: "${{ github.token }}"
 outputs:
   changelog:
     description: "output file"
@@ -37,14 +36,14 @@ runs:
         RUNNER_OS: ${{ runner.os }}
         RUNNER_ARCH: ${{ runner.arch }}
         VERSION: ${{ inputs.version }}
-        GITHUB_API_TOKEN: ${{ inputs.github_token }}
+        GITHUB_API_TOKEN: ${{ inputs.github_token || env.GITHUB_TOKEN || github.token }}
 
     - name: Run git-cliff
       id: run-git-cliff
       shell: bash
       run: ${GITHUB_ACTION_PATH}/run.sh --config=${{ inputs.config }} ${{ inputs.args }}
       env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token || env.GITHUB_TOKEN || github.token }}
 
 branding:
   icon: "triangle"


### PR DESCRIPTION
Fix for #72 (improves #74)

This should properly handle "github tokens" precedence.

1. Input `github_token`
2. env `GITHUB_TOKEN`
3. default `github.token`