### PR TITLE
ci(sync): resolve github cli login

### DIFF
--- a/.github/workflows/sync-git-cliff-version.yml
+++ b/.github/workflows/sync-git-cliff-version.yml
@@ -60,7 +60,6 @@ jobs:
           git commit -m "${TITLE}" || echo "Nothing to commit"
           git push origin "${BRANCH}" --force
 
-          echo "${GITHUB_TOKEN}" | gh auth login --with-token
           gh pr create \
             --base main \
             --head "${BRANCH}" \


### PR DESCRIPTION
I noticed the sync workflow was failing with the following message:
```
The value of the GITHUB_TOKEN environment variable is being used for authentication.
To have GitHub CLI store credentials instead, first clear the value from the environment.
```
Example: https://github.com/orhun/git-cliff-action/actions/runs/24954316040/job/73069823999#step:6:43

Fortunately, the GitHub CLI automatically logs in when using the `GITHUB_TOKEN` environment variable. Therefore, I have removed the `echo "${GITHUB_TOKEN}" | gh auth login --with-token` line. https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-github-cli can also be viewed to see this.


