### PR TITLE
fix: use BSD-compatible stat format on macOS

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,8 +21,10 @@ GIT_CLIFF_PATH="$RUNNER_TEMP/git-cliff/bin/$GIT_CLIFF_BIN"
 # otherwise is GNU stat
 if [[ "${RUNNER_OS}" == "macOS" ]]; then
     stat_cmd=(stat -f)
+    size_fmt='%z'
 else
     stat_cmd=(stat -c)
+    size_fmt='%s'
 fi
 
 # Set up working directory
@@ -66,7 +68,7 @@ GIT_CLIFF_OUTPUT="$CONTEXT" "$GIT_CLIFF_PATH" --context "${args[@]}"
 chown -R "$owner" .
 
 # Set the changelog content (max: 50MB)
-FILESIZE=$("${stat_cmd[@]}" %s "$OUTPUT")
+FILESIZE=$("${stat_cmd[@]}" "$size_fmt" "$OUTPUT")
 MAXSIZE=$((40 * 1024 * 1024))
 if [ "$FILESIZE" -le "$MAXSIZE" ]; then
     echo "content<<EOF" >>$GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

On macOS runners, `outputs.content` is silently empty because `run.sh:69` uses GNU-stat syntax that BSD stat rejects:

```
$ stat -f %s file
stat: %s: bad format
```

BSD stat (the macOS default) uses `%z` for file size in bytes, not `%s`. The earlier `stat_cmd` selector at line 22-26 picks `stat -f` vs `stat -c` correctly, but the size format string on line 69 is hard-coded to `%s` and assumes GNU.

The resulting empty `FILESIZE` makes the `[ "" -le 41943040 ]` test error with \"integer expression expected\", and the `content<<EOF` block inside it never runs — so the step appears to succeed but produces no output. Downstream `steps.<id>.outputs.content` references resolve to an empty string.

## Fix

Introduce a parallel `size_fmt` variable next to `stat_cmd`, set per-platform:

| Platform | `stat_cmd` | `size_fmt` |
| --- | --- | --- |
| macOS  | `stat -f` | `%z` |
| Linux/Windows | `stat -c` | `%s` |

Then use `"$size_fmt"` on line 69.

## Verification

- **macOS (BSD stat):** `stat -f %z run.sh` → `1995` ✓ (vs `stat -f %s run.sh` → `stat: %s: bad format`)
- **Linux (GNU stat, alpine/bash:5 container):** ran the modified script logic, `FILESIZE=1995`, size check passes ✓

## Repro

The bug surfaces on any macOS workflow that relies on `steps.<id>.outputs.content` from this action. Example failing run: empty release body even though git-cliff itself writes the expected markdown to its output file.