### PR TITLE
fix(action): always terminate content output with a newline

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -70,8 +70,8 @@ FILESIZE=$("${stat_cmd[@]}" %s "$OUTPUT")
 MAXSIZE=$((40 * 1024 * 1024))
 if [ "$FILESIZE" -le "$MAXSIZE" ]; then
     echo "content<<EOF" >>$GITHUB_OUTPUT
-    cat "$OUTPUT" >>$GITHUB_OUTPUT
-    printf '\nEOF\n' >>$GITHUB_OUTPUT
+    awk 1 "$OUTPUT" >>$GITHUB_OUTPUT
+    echo "EOF" >>$GITHUB_OUTPUT
     cat "$OUTPUT"
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -71,7 +71,7 @@ MAXSIZE=$((40 * 1024 * 1024))
 if [ "$FILESIZE" -le "$MAXSIZE" ]; then
     echo "content<<EOF" >>$GITHUB_OUTPUT
     cat "$OUTPUT" >>$GITHUB_OUTPUT
-    echo "EOF" >>$GITHUB_OUTPUT
+    printf '\nEOF\n' >>$GITHUB_OUTPUT
     cat "$OUTPUT"
 fi
 


### PR DESCRIPTION
## Problem

`run.sh` writes the changelog to `$GITHUB_OUTPUT` as a multiline value:

```bash
echo "content<<EOF" >>$GITHUB_OUTPUT
cat "$OUTPUT" >>$GITHUB_OUTPUT
echo "EOF" >>$GITHUB_OUTPUT
```

`cat "$OUTPUT" >> $GITHUB_OUTPUT` does not append a trailing newline, so when the changelog ends without one (a common case — git-cliff often emits output that way) the closing `EOF` is appended to the last content line. The step then fails with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid value. Matching delimiter not found 'EOF'
```

## Fix

Replace `echo "EOF"` with `printf '\nEOF\n'` so the closing marker always lands on its own line. Worst case (when the content already ended with a newline) the value gains one trailing blank line, which is harmless.

## Verification

Reproduced locally against a real git-cliff output with no trailing newline.

Before:

```
**Full Changelog**: .../v0.0.12...v0.0.13EOF
changelog=...
```

After:

```
**Full Changelog**: .../v0.0.12...v0.0.13

EOF
changelog=...
```
